### PR TITLE
inputs.items(): AttributeError: 'str' object has no attribute 'items'

### DIFF
--- a/awx-migrate
+++ b/awx-migrate
@@ -180,12 +180,20 @@ def awx_getdb_creds():
     for row in table:
         name = row[1]
         if name not in awx_creds:
-            cred = dict(pk=row[0],
-                        name=row[1],
-                        organization_id=row[2],
-                        inputs=row[3],
-                        credential_type_id=row[4],
-                        )
+            if type(row[3]) == str:
+                cred = dict(pk=row[0],
+                            name=row[1],
+                            organization_id=row[2],
+                            inputs=json.loads(row[3]),
+                            credential_type_id=row[4],
+                            )
+            else:
+                cred = dict(pk=row[0],
+                            name=row[1],
+                            organization_id=row[2],
+                            inputs=row[3],
+                            credential_type_id=row[4],
+                            )
             row2dict = {name: cred}
         else:
             _err = "duplicate cred found: %s", name


### PR DESCRIPTION
when i was utilizing this tool on my AWX installation, i found that cred inputs key value was an long string to the program could not run.
My solution was to use inputs=json.loads(row[3]) to overcome the issue. 

./awx-migrate-wrapper
Traceback (most recent call last):
  File "./awx-migrate", line 359, in <module>
    main()
  File "./awx-migrate", line 355, in main
    awx_receive_objects()
  File "./awx-migrate", line 261, in awx_receive_objects
    awx_creds = decrypt_inputs(awx_getdb_creds())
  File "./awx-migrate", line 210, in decrypt_inputs
    for k, v in inputs.items():
AttributeError: 'str' object has no attribute 'items'